### PR TITLE
replace gaussian matrix with count matrix

### DIFF
--- a/matlab/sparsify/approxReff.m
+++ b/matlab/sparsify/approxReff.m
@@ -23,7 +23,11 @@ m = length(ai);
 
 nvecs = ceil(c*log(m));
 
-R = randn(m,nvecs);
+
+% R = randn(m,nvecs);
+R = countMatrix(m, nvecs);
+
+
 B = U*Wh*R;
 
 Z = zeros(size(B));

--- a/matlab/sparsify/approxReff.m
+++ b/matlab/sparsify/approxReff.m
@@ -23,10 +23,11 @@ m = length(ai);
 
 nvecs = ceil(c*log(m));
 
-
-% R = randn(m,nvecs);
-R = countMatrix(m, nvecs);
-
+if m < 1000
+    R = randn(m,nvecs);
+else
+    R = countMatrix(m, nvecs);
+end
 
 B = U*Wh*R;
 

--- a/matlab/util/countMatrix.m
+++ b/matlab/util/countMatrix.m
@@ -1,0 +1,10 @@
+function cm = countMatrix(n, h)
+% function cm = countMatrix(n, h)
+% create a sparse n by h count matrix
+
+i = 1:n;
+j = randi(h, 1, n);
+
+v = randi(2, 1, n) * 2 - 3;
+cm = sparse(i, j, v, n, h);
+end


### PR DESCRIPTION
Hi,
I note that  when `m` is large (say e.g. you want to return the effective resistance for all edges), the following code may blow up the space
 
       nvecs = ceil(c*log(m));
       R = randn(m,nvecs);

Since the only point to use R is to reserve the L2 norm, we can use a sparse matrix instead. A count matrix is a sparse matrix. Each column of a count matrix has only one non-zero entry, chosen from {-1, 1}. An example is

      0   0   1   0   -1
      -1  0   0   1    0
      0   1   0   0    0

it is well known that the count matrix can also reserve the L2 norm. So replace the gaussian matrix with the count matrix can significantly save the memory usage and running time.


More information about count matrix can be found in [1] (see page 19).

[1]: Woodruff, David P. ["Sketching as a tool for numerical linear algebra."](http://researcher.watson.ibm.com/researcher/files/us-dpwoodru/wNow3.pdf)  